### PR TITLE
Fix topup() passing literal string instead of check.id

### DIFF
--- a/lib/pokepay_sdk.dart
+++ b/lib/pokepay_sdk.dart
@@ -275,7 +275,7 @@ class PokepayClient {
   Future<UserTransaction> topup(
       {required Check check, String? accountId}) async {
     return await this.api.createUserTransactionWithCheck(
-        checkId: 'check.id', accountId: accountId);
+        checkId: check.id, accountId: accountId);
   }
 
   Future<UserTransaction> invokeToken({


### PR DESCRIPTION
## 概要

`PokepayClient.topup()` が `createUserTransactionWithCheck` の `checkId` に、実際の値ではなく**文字列リテラル `'check.id'`** を渡していたバグを修正します。

## 問題点

```dart
Future<UserTransaction> topup({required Check check, String? accountId}) async {
  return await this.api.createUserTransactionWithCheck(
      checkId: 'check.id', accountId: accountId);  // ← リテラル文字列
}
```

- 必須引数の `check` が全く使われていない
- 常に無効なチェック識別子 `'check.id'` がネイティブSDKへ送信され、topup が正しく機能しない

## 修正

```dart
      checkId: check.id, accountId: accountId);
```

ネイティブ側(Android `CreateTransactionWithCheck(checkId, ...)` / iOS `CreateWithCheck(checkId: ...)`)は check の ID を期待しているため、`check.id`(`String`型)を渡すのが正しい実装です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)