### PR TITLE
Fix invokeToken sending the wrong argument key and Android NPEs on optional args

### DIFF
--- a/android/src/main/java/jp/pokepay/pokepay_sdk/PokepaySdkPlugin.java
+++ b/android/src/main/java/jp/pokepay/pokepay_sdk/PokepaySdkPlugin.java
@@ -232,6 +232,7 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
         }
 
         private TransactionStrategy parseTxStrategy(String strategy){
+            if (strategy == null) return TransactionStrategy.POINT_PREFERRED;
             switch (strategy){
                 case "money-only": return TransactionStrategy.MONEY_ONLY;
                 case "point-preferred": return TransactionStrategy.POINT_PREFERRED;
@@ -397,7 +398,8 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
                         TransactionStrategy txStrategy = parseTxStrategy(rawStrategy);
                         Double amount = call.argument("amount");
                         String rawRequestId = call.argument("requestId");
-                        UUID requestId = UUID.fromString(rawRequestId);
+                        // requestId は省略可能。UUID.fromString(null) は NPE になる
+                        UUID requestId = rawRequestId == null ? null : UUID.fromString(rawRequestId);
                         if (amount != null){
                             req = new CreateTransactionWithBill(billId, accountId, amount, couponId, txStrategy, requestId);
                         }else{
@@ -416,7 +418,8 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
                         String couponId = call.argument("couponId");
                         String rawStrategy = call.argument("tx_strategy");
                         String rawRequestId = call.argument("requestId");
-                        UUID requestId = UUID.fromString(rawRequestId);
+                        // requestId は省略可能。UUID.fromString(null) は NPE になる
+                        UUID requestId = rawRequestId == null ? null : UUID.fromString(rawRequestId);
                         TransactionStrategy txStrategy = parseTxStrategy(rawStrategy);
                         Integer topupQuotaId = call.argument("topupQuotaId");
                         CreateTransactionWithCashtray req = new CreateTransactionWithCashtray(cashtrayId, accountId, couponId,txStrategy,requestId).topupQuotaId(topupQuotaId);
@@ -430,7 +433,8 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
                         String checkId = call.argument("checkId");
                         String accountId = call.argument("accountId");
                         String rawRequestId = call.argument("requestId");
-                        UUID requestId = UUID.fromString(rawRequestId);
+                        // requestId は省略可能。UUID.fromString(null) は NPE になる
+                        UUID requestId = rawRequestId == null ? null : UUID.fromString(rawRequestId);
                         Integer topupQuotaId = call.argument("topupQuotaId");
                         CreateTransactionWithCheck req = new CreateTransactionWithCheck(checkId, accountId, requestId).topupQuotaId(topupQuotaId);
                         Pokepay.setEnv(env);
@@ -447,7 +451,8 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
                         final ObjectMapper mapper = JsonConverter.createObjectMapper();
                         Product[] products = mapper.readValue(productsString,  Product[].class);
                         String rawRequestId = call.argument("requestId");
-                        UUID requestId = UUID.fromString(rawRequestId);
+                        // requestId は省略可能。UUID.fromString(null) は NPE になる
+                        UUID requestId = rawRequestId == null ? null : UUID.fromString(rawRequestId);
                         Integer topupQuotaId = call.argument("topupQuotaId");
                         CreateTransactionWithCpm req = new CreateTransactionWithCpm(cpmToken, accountId, amount, products, requestId).topupQuotaId(topupQuotaId);
                         Pokepay.setEnv(env);
@@ -824,7 +829,8 @@ public class PokepaySdkPlugin implements FlutterPlugin, MethodCallHandler {
                         TransactionStrategy txStrategy = parseTxStrategy(rawStrategy);
                         String privateMoneyId = call.argument("privateMoneyId");
                         String rawRequestId = call.argument("requestId");
-                        UUID requestId = UUID.fromString(rawRequestId);
+                        // requestId は省略可能。UUID.fromString(null) は NPE になる
+                        UUID requestId = rawRequestId == null ? null : UUID.fromString(rawRequestId);
                         Pokepay.Client client;
                         UserTransaction userTransaction;
 

--- a/lib/pokepay_sdk.dart
+++ b/lib/pokepay_sdk.dart
@@ -281,10 +281,14 @@ class PokepayClient {
   Future<UserTransaction> invokeToken({
     required String token,
   }) async {
+    // ネイティブ側の scanToken は 'scanToken' キーを読む。
+    // 以前は 'token' キーで送っていたため常に null になり機能していなかった。
     String json = await channel.invokeMethod('scanToken', {
       'env': envToInt(this.api.env),
       'accessToken': this.api.accessToken,
-      'token': token,
+      'scanToken': token,
+      'tx_strategy': TransactionStrategy.POINT_PREFERRED.value,
+      'privateMoneyId': this.privateMoneyId,
     });
     return UserTransaction.fromJson(jsonDecode(json));
   }


### PR DESCRIPTION
## Summary
- **invokeToken が機能していなかった問題の修正**: Dart 側が `'token'` キーで送る一方、ネイティブの `scanToken` ハンドラは `'scanToken'` キーを読むため、トークンが常に null になっていた(整合性リントで検出)。キーを修正し、`scanToken` メソッドと同様に `tx_strategy`(point-preferred)と `privateMoneyId`(カスタムドメイン対応)も送るようにした
- **Android: requestId 省略時の NPE 修正**: `UUID.fromString(null)` が NPE を投げるため、`requestId`(省略可能)を渡さない場合に createUserTransactionWithBill / Cashtray / Check / Cpm / scanToken の全5ハンドラがクラッシュする状態だった。null 安全にパース
- **Android: `parseTxStrategy(null)` の NPE 修正**: Java の String switch は null で NPE になる。iOS 実装(`parseStrategy`)と同じく POINT_PREFERRED にフォールバック

## 補足
- #51 (autogen ネイティブリンク) とは独立した master 起点の修正です
- iOS 側は `as?` / `UUID(uuidString: rawRequestId ?? "")` で元から null 安全のため変更なし

## Test plan
- [x] flutter analyze: No issues found
- [ ] Android 実機/エミュレータで requestId 省略の pay() / scanToken() が成功すること
- [ ] invokeToken でトークン文字列が正しくネイティブに渡ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)